### PR TITLE
Configurable global PATH lookup for TypeScript LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ vim.lsp.config("ts_bridge", {
       separate_diagnostic_server = true,      -- launch syntax + semantic tsserver
       publish_diagnostic_on = "insert_leave",
       enable_inlay_hints = true,
+      -- if you've aliased 'tsserver' or would like to refer to a
+      -- different path, assign that to `tsserver_cmd`
+      -- tsserver_cmd = 'tsserver'
       tsserver = {
         locale = nil,
         log_directory = nil,
@@ -198,6 +201,10 @@ lspconfig.ts_bridge.setup({
 
 If you built locally instead of installing, swap `cmd = { "ts-bridge" }` for the
 absolute binary path (for example, `cmd = { "/path/to/ts-bridge" }`).
+
+In case you'd like to use a different path for `tsserver`, or refer to an
+alias, assign such to the `tsserver_cmd` field in the top-level settings
+table for `ts-bridge`.
 
 Because `ts-bridge` delays spawning `tsserver` until the first routed request,
 these defaults (or any overrides you make) apply to both syntax and semantic

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,8 @@ pub struct PluginSettings {
     pub publish_diagnostic_on: DiagnosticPublishMode,
     /// Launch arguments and logging preferences forwarded to tsserver.
     pub tsserver: TsserverLaunchOptions,
+    /// Possible user alias for tsserver binary
+    pub tsserver_cmd: String,
     /// User preferences forwarded to the tsserver `configure` command.
     pub tsserver_preferences: Map<String, Value>,
     /// Formatting options forwarded to the tsserver `configure` command.
@@ -35,6 +37,7 @@ impl Default for PluginSettings {
             separate_diagnostic_server: true,
             publish_diagnostic_on: DiagnosticPublishMode::InsertLeave,
             tsserver: TsserverLaunchOptions::default(),
+            tsserver_cmd: String::from("tsserver"),
             tsserver_preferences: Map::new(),
             tsserver_format_options: Map::new(),
             enable_inlay_hints: true,
@@ -126,6 +129,14 @@ impl PluginSettings {
                 changed = true;
             }
         }
+
+        if let Some(value) = map.get("tsserver_cmd").and_then(|v| v.as_str()) {
+            if self.tsserver_cmd != value {
+                self.tsserver_cmd = String::from(value);
+                changed = true;
+            }
+        }
+
 
         if let Some(tsserver) = map.get("tsserver") {
             changed |= self.tsserver.update_from_value(tsserver);

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -63,7 +63,7 @@ impl Provider {
     /// 1. `node_modules/typescript/lib/tsserver.js` in workspace ancestors.
     /// 2. `.yarn/sdks/typescript/lib/tsserver.js` in ancestors.
     /// 3. `tsserver` on PATH (via `which`).
-    pub fn resolve(&mut self) -> Result<TsserverBinary, ProviderError> {
+    pub fn resolve(&mut self, cmd: &str) -> Result<TsserverBinary, ProviderError> {
         if let Some(path) = self.find_local_node_modules() {
             self.reanchor_workspace_root(&path);
             let plugin_probe = path
@@ -92,7 +92,7 @@ impl Provider {
             ));
         }
 
-        if let Some(path) = self.find_global_tsserver()? {
+        if let Some(path) = self.find_global_tsserver(cmd)? {
             return Ok(TsserverBinary::new(path, None, BinarySource::GlobalPath));
         }
 
@@ -129,8 +129,8 @@ impl Provider {
         })
     }
 
-    fn find_global_tsserver(&self) -> Result<Option<PathBuf>, ProviderError> {
-        match which::which("tsserver") {
+    fn find_global_tsserver(&self, cmd: &str) -> Result<Option<PathBuf>, ProviderError> {
+        match which::which(cmd) {
             Ok(path) => {
                 // Some distributions expose a wrapper script; if so try to backtrack to the JS file.
                 if path.file_name().and_then(|f| f.to_str()) == Some("tsserver.js") {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -45,7 +45,8 @@ impl Service {
 
     /// Bootstraps tsserver processes once
     pub fn start(&mut self) -> Result<(), ServiceError> {
-        let binary = self.provider.resolve().map_err(ServiceError::Provider)?;
+        let tsserver_cmd = &self.config.plugin().tsserver_cmd;
+        let binary = self.provider.resolve(tsserver_cmd).map_err(ServiceError::Provider)?;
         let launch = self.config.plugin().tsserver.clone();
         let mut syntax = TsserverProcess::new(ServerKind::Syntax, binary.clone(), launch.clone());
         syntax.start().map_err(ServiceError::Process)?;


### PR DESCRIPTION
Addresses issue identified in #1 when `node_modules` not installed 